### PR TITLE
Add simple sorting utility

### DIFF
--- a/sort_utils.py
+++ b/sort_utils.py
@@ -1,12 +1,15 @@
-def sort_numbers(numbers):
-    """Return a list of numbers sorted in ascending order."""
+from typing import Iterable, List
+
+
+def sort_numbers(numbers: Iterable[int]) -> List[int]:
+    """Return a list of integers sorted in ascending order."""
     return sorted(numbers)
 
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Sort numbers in ascending order.")
-    parser.add_argument("numbers", nargs="+", type=float, help="Numbers to sort.")
+    parser.add_argument("numbers", nargs="+", type=int, help="Numbers to sort.")
     args = parser.parse_args()
     sorted_nums = sort_numbers(args.numbers)
-    print(sorted_nums)
+    print(" ".join(str(n) for n in sorted_nums))
 

--- a/sort_utils.py
+++ b/sort_utils.py
@@ -1,0 +1,12 @@
+def sort_numbers(numbers):
+    """Return a list of numbers sorted in ascending order."""
+    return sorted(numbers)
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Sort numbers in ascending order.")
+    parser.add_argument("numbers", nargs="+", type=float, help="Numbers to sort.")
+    args = parser.parse_args()
+    sorted_nums = sort_numbers(args.numbers)
+    print(sorted_nums)
+

--- a/test_sort_utils.py
+++ b/test_sort_utils.py
@@ -1,0 +1,6 @@
+from sort_utils import sort_numbers
+
+
+def test_sort_numbers_sorts_integers():
+    assert sort_numbers([5, 3, 7, 1, 0]) == [0, 1, 3, 5, 7]
+


### PR DESCRIPTION
## Summary
- add `sort_numbers` helper and CLI for sorting lists of numbers

## Testing
- `python sort_utils.py 5 3 7 1`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896b5fdac0483339c688fb766576303